### PR TITLE
fix: correct token parameter bug and docstring typo

### DIFF
--- a/src/purl_license_checker/cli.py
+++ b/src/purl_license_checker/cli.py
@@ -86,7 +86,7 @@ def load_csv(path: str, token: str) -> None:
 @click.argument("purl")
 @click.argument("token")
 def get_purl_license(purl: str, token: str) -> None:
-    click.echo(parser.get_license(purl=purl, token=str))
+    click.echo(parser.get_license(purl=purl, token=token))
 
 
 @cli.command("merge_csv")

--- a/src/purl_license_checker/parser.py
+++ b/src/purl_license_checker/parser.py
@@ -171,7 +171,7 @@ def get_nuget_license(purlfmt: PackageURL):
 
 def get_php_license(purlfmt: PackageURL):
     """
-    Fetch packagists.org to discover a license
+    Fetch packagist.org to discover a license
 
     Ex: https://repo.packagist.org/p2/symfony/event-dispatcher-contracts.json
     """


### PR DESCRIPTION
## Summary

Fix 2 issues across 2 files:

- `src/purl_license_checker/cli.py`: Fix bug where `str` builtin was passed instead of the `token` variable to `parser.get_license()` in the `get_license` CLI command
- `src/purl_license_checker/parser.py`: Fix typo "packagists.org" to "packagist.org" in `get_php_license()` docstring

The first fix is a behavioral bug fix — the `get_license` CLI command was always passing the `str` type object instead of the user-supplied token, causing authentication to silently fail for any PURL type that requires a token (e.g., GitHub Actions, Maven).